### PR TITLE
Eliminar novedad desde Backoffice [OT242-87]

### DIFF
--- a/src/components/backNewsList/NewsItem.js
+++ b/src/components/backNewsList/NewsItem.js
@@ -3,33 +3,36 @@ import { FaTrash, FaEdit } from "react-icons/fa";
 import { delReq } from "../../helpers/ReqToApi";
 import Swal from "sweetalert2";
 
-// función para eliminar novedad
-const deleteNew = async (id) => {
-  try {
-    await delReq(`/admin/news/${id}`);
-    window.location.reload();
-  } catch (err) {
-    console.log(err);
-  }
-};
-// función de confirmación para Sweet Alert 2
-const confirmDelete = (id) => {
-  Swal.fire({
-    title: "Estas seguro?",
-    text: "No podrás revertir esta acción!",
-    icon: "warning",
-    showCancelButton: true,
-    confirmButtonColor: "#3085d6",
-    cancelButtonColor: "#d33",
-    confirmButtonText: "Si, borrar novedad!",
-  }).then((result) => {
-    if (result.isConfirmed) {
-      deleteNew(id);
-    }
-  });
-};
 const NewsItem = (props) => {
-  const { id, name, image, createdAt } = props;
+
+  const { id, name, image, createdAt, loadNews } = props;
+
+// función para eliminar novedad
+  const deleteNew = async (id) => {
+    try {
+      await delReq(`/admin/news/${id}`);
+      loadNews()
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+// función de confirmación para Sweet Alert 2
+  const confirmDelete = (id) => {
+    Swal.fire({
+      title: "Estas seguro?",
+      text: "No podrás revertir esta acción!",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: "Si, borrar novedad!",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        deleteNew(id);
+      }
+    });
+  };
 
   return (
     <>

--- a/src/components/backNewsList/NewsItem.js
+++ b/src/components/backNewsList/NewsItem.js
@@ -1,24 +1,58 @@
-import React from 'react';
-import { FaTrash, FaEdit } from 'react-icons/fa';
+import React from "react";
+import { FaTrash, FaEdit } from "react-icons/fa";
+import { delReq } from "../../helpers/ReqToApi";
+import Swal from "sweetalert2";
 
+// función para eliminar novedad
+const deleteNew = async (id) => {
+  try {
+    await delReq(`/admin/news/${id}`);
+    window.location.reload();
+  } catch (err) {
+    console.log(err);
+  }
+};
+// función de confirmación para Sweet Alert 2
+const confirmDelete = (id) => {
+  Swal.fire({
+    title: "Estas seguro?",
+    text: "No podrás revertir esta acción!",
+    icon: "warning",
+    showCancelButton: true,
+    confirmButtonColor: "#3085d6",
+    cancelButtonColor: "#d33",
+    confirmButtonText: "Si, borrar novedad!",
+  }).then((result) => {
+    if (result.isConfirmed) {
+      deleteNew(id);
+    }
+  });
+};
 const NewsItem = (props) => {
-    const { id, name, image, createdAt } = props;
+  const { id, name, image, createdAt } = props;
 
-    return (
-      <>
-        <tbody>
-          <th scope="row" style={{display:'none',}}>{id}</th>
-          <td>{name}</td>
-          <td>{image}</td>
-          <td>{createdAt}</td>
-          <td class="acciones">
-             <FaTrash></FaTrash>
-             <FaEdit></FaEdit>
-          </td>
-        </tbody>
-      </>
-
-    );
-}
+  return (
+    <>
+      <tbody>
+        <th scope="row" style={{ display: "none" }}>
+          {id}
+        </th>
+        <td>{name}</td>
+        <td>{image}</td>
+        <td>{createdAt}</td>
+        <td class="acciones">
+          <button
+            onClick={() => {
+              confirmDelete(id);
+            }}
+          >
+            <FaTrash></FaTrash>
+          </button>
+          <FaEdit></FaEdit>
+        </td>
+      </tbody>
+    </>
+  );
+};
 
 export default NewsItem;

--- a/src/pages/BackOffice/newsPage/backofficeNews.js
+++ b/src/pages/BackOffice/newsPage/backofficeNews.js
@@ -77,6 +77,7 @@ const BackNewsPage = (props) => {
           news.map((item) => (
             <NewsItem
               key={item.id}
+              id={item.id}
               name={item.name}
               image={item.image}
               createdAt={item.createdAt.slice(0, 10)}

--- a/src/pages/BackOffice/newsPage/backofficeNews.js
+++ b/src/pages/BackOffice/newsPage/backofficeNews.js
@@ -12,14 +12,14 @@ const BackNewsPage = (props) => {
   const [cats, setCats] = useState([]);
   const [value, setValue] = useState("");
 
-  useEffect(() => {
-    const loadNews = async () => {
-      setLoading(true);
-      const response = await getReq(`/admin/news`);
-      setNews(response.data);
-      setLoading(false);
-    };
+  const loadNews = async () => {
+    setLoading(true);
+    const response = await getReq(`/admin/news`);
+    setNews(response.data);
+    setLoading(false);
+  };
 
+  useEffect(() => {
     loadNews();
   }, []);
 
@@ -80,6 +80,7 @@ const BackNewsPage = (props) => {
               id={item.id}
               name={item.name}
               image={item.image}
+              loadNews={loadNews}
               createdAt={item.createdAt.slice(0, 10)}
             />
           ))


### PR DESCRIPTION
[Tarea de Jira](https://alkemy-labs.atlassian.net/browse/OT242-87)
RESUMEN:
- Se tuvo que cambiar el server en [ESTE PR](https://github.com/alkemyTech/OT242-Server/pull/49) ya que el controller y las rutas para traer todas las novedades solo traía las que tienen 'news' de categoría. Esto afectaba también a la página pública de novedades.
- Se agregó funcionalidad al botón para borrar una novedad, efectuadose este cambio en la base de datos.
- Se utilizó sweetalert2 para la alerta de confirmación, librería previamente instalada en el proyecto.

EVIDENCIA:
base de datos inicial:
![bd1](https://user-images.githubusercontent.com/91494874/184042090-dd6ad06a-cbcc-464b-9733-b79dbbc6e54d.png)
vista de /backoffice/news:
![state1](https://user-images.githubusercontent.com/91494874/184042118-9f8114ca-2797-491d-bc58-807778f937b7.png)
al presionar en delete:
![state2](https://user-images.githubusercontent.com/91494874/184042137-83fb610e-8cf7-41e8-9832-db2add5b75b0.png)
al confirmar la alerta:
![state3](https://user-images.githubusercontent.com/91494874/184042141-0d613c69-b5f4-4c89-be92-ca114f6548d0.png)
base de datos final:
![bd2](https://user-images.githubusercontent.com/91494874/184042592-2dd3b290-5f5e-4321-b7c7-6ab3d1d42373.png)

