### PR TITLE
Protect backoffice and login-register routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
-// import Registration from './UI/registration/UIRegistration'; Module not found: Can't resolve './alerts/ErrorAlertAuth'
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import PrivateRoute from './components/ProtectedRoutes/PrivateRoute';
+import LoggedRoute from './components/ProtectedRoutes/LoggedRoute';
 
 // public
 import Header from './components/header/Header';
@@ -42,25 +43,24 @@ function App() {
             <Route path="/testimonials" element={<TestimonialsPage />} />
             <Route path="/contact" element={<ContactPage />} />
             <Route path="*" element={<Navigate replace to="/" />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/registrate" element={<Register />} />
             <Route path="/news" element={<NewsPage />} />
             <Route path="/news/:id" element={<NewsDetail/>} />
 
             {/* BackOffice */}
-            <Route path="/backoffice/news" element={<BackNewsPage />} />
+            <Route path="/backoffice/news" element={<PrivateRoute><BackNewsPage /></PrivateRoute>} />
             <Route path="*" element={<Navigate replace to="/" />} />
-            <Route path="/backoffice" element={<BackOffice />} />
-            <Route path="/backoffice/users" element={<BackOfficeUsers />} />
-            <Route path="/backoffice/contacts" element={<ContactsTable />} />
-            <Route path="/backoffice/activities" element={<ActList />} />
-            <Route path="/backoffice/activities/edit/:id" element={<ActForm />} />
-            <Route path="/backoffice/testimonials" element={<BackTestimonialPage />} />
+            <Route path="/backoffice" element={<PrivateRoute><BackOffice /></PrivateRoute>} />
+            <Route path="/backoffice/users" element={<PrivateRoute><BackOfficeUsers /></PrivateRoute>} />
+            <Route path="/backoffice/contacts" element={<PrivateRoute><ContactsTable /></PrivateRoute>} />
+            <Route path="/backoffice/activities" element={<PrivateRoute><ActList /></PrivateRoute>} />
+            <Route path="/backoffice/activities/edit/:id" element={<PrivateRoute><ActForm /></PrivateRoute>} />
+            <Route path="/backoffice/testimonials" element={<PrivateRoute><BackTestimonialPage /></PrivateRoute>} />
+            <Route path="/newsForm/:id" element={<PrivateRoute><NewsFormPage /></PrivateRoute>} />
+            <Route path="/newsForm/" element={<PrivateRoute><NewsFormPage /></PrivateRoute>} />
 
-
-            {/* News creation and update */}
-            <Route path="/newsForm/:id" element={<NewsFormPage />} />
-            <Route path="/newsForm/" element={<NewsFormPage />} />
+            {/* Users */}
+            <Route path="/login" element={<LoggedRoute><Login /></LoggedRoute>} />
+            <Route path="/registrate" element={<LoggedRoute><Register /></LoggedRoute>} />
 
           </Routes>
         <Footer />

--- a/src/components/ProtectedRoutes/LoggedRoute.js
+++ b/src/components/ProtectedRoutes/LoggedRoute.js
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+
+const LoggedRoute = ({children}) => {
+    let token = localStorage.getItem('token');
+
+    return !token ? children : <Navigate to="/"/>;
+        
+
+}
+
+export default LoggedRoute;

--- a/src/components/ProtectedRoutes/PrivateRoute.js
+++ b/src/components/ProtectedRoutes/PrivateRoute.js
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+
+const PrivateRoute = ({children}) => {
+    let dataUser = JSON.parse(localStorage.getItem('dataUser002'));
+
+    return dataUser && dataUser.roleId === 1 ? children : <Navigate to="/login"/>;
+        
+
+}
+
+export default PrivateRoute;


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT242-103

Creo lógica para proteger las rutas del backoffice: Al no estar logueado o ser usuario con roleId diferente a 1 (Admin), redirecciona al Login.
También creo la protección de las rutas del Login y Register form para que si el usuario ya está logueado, lo direccione al home.
No realizo la de la ruta de edición de usuario ya que esta aún no existe.

Ejemplo tratando de acceder a la ruta: /backoffice/news

https://user-images.githubusercontent.com/101156536/184277978-2516c826-6d82-452c-8447-ca0dd701d82e.mp4




